### PR TITLE
removed python from install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,9 @@
 echo "Let's get you set up with Rustlings!"
 
 echo "Checking requirements..."
-if [ -x "$(command -v git)" ]
+# check that our shell has `command` else fall back to `which` 
+WHICH_CMD=$(command -v command && printf '%s' '-v'||echo 'which');
+if [ -x "$($WHICH_CMD git)" ]
 then
     echo "SUCCESS: Git is installed"
 else
@@ -12,7 +14,7 @@ else
     exit 1
 fi
 
-if [ -x "$(command -v rustc)" ]
+if [ -x "$($WHICH_CMD rustc)" ]
 then
     echo "SUCCESS: Rust is installed"
 else
@@ -21,7 +23,7 @@ else
     exit 1
 fi
 
-if [ -x "$(command -v cargo)" ]
+if [ -x "$($WHICH_CMD cargo)" ]
 then
     echo "SUCCESS: Cargo is installed"
 else
@@ -30,25 +32,38 @@ else
     exit 1
 fi
 
-# Look up python installations, starting with 3 with a fallback of 2
-if [ -x "$(command -v python3)" ]
+INSTALL_JQ=0 # If you would like this scrip to install jq then set this to "1"
+
+if [ "$INSTALL_JQ" ]&&[ "$INSTALL_JQ" -eq 1 ]
 then
-    PY="$(command -v python3)"
-elif [ -x "$(command -v python)" ]
+    # install jq for faster and more efficient json parsing
+    if [ -x "$($WHICH_CMD brew)" ] && uname -a|grep -q Darwin;
+    then # probably OSX
+        command -v jq 1>/dev/null|| $($WHICH_CMD brew) install jq
+    elif [ -x "$($WHICH_CMD apt)" ] && uname -a|grep -q Linux;
+    then # debian flavour
+        command -v jq 1>/dev/null|| sudo $($WHICH_CMD apt) install -y jq
+    elif [ -x "$($WHICH_CMD apt-get)" ] && uname -a|grep -q Linux;
+    then # (older) debian flavour
+        command -v jq 1>/dev/null|| sudo $($WHICH_CMD apt-get) install -y jq
+    elif [ -x "$($WHICH_CMD yum)" ] && uname -a|grep -q Linux;
+    then # Linux with `yum` package manager
+        $WHICH_CMD jq 1>/dev/null|| sudo $($WHICH_CMD yum) install -y jq
+    fi
+fi #/end of optional `jq` install
+
+if [ -x "$($WHICH_CMD jq)" ]
 then
-    PY="$(command -v python)"
-elif [ -x "$(command -v python2)" ]
-then
-    PY="$(command -v python2)"
+    JQ="$($WHICH_CMD jq)" #jq is much faster than python for json parsing
 else
-    echo "ERROR: No working python installation was found"
-    echo "Please install python and add it to the PATH variable"
-    exit 1
+    echo "INFO: jq not located; falling back to sub-optimal native shell json parsing"
+    JQ=""
 fi
+
 
 # Function that compares two versions strings v1 and v2 given in arguments (e.g 1.31 and 1.33.0).
 # Returns 1 if v1 > v2, 0 if v1 == v2, 2 if v1 < v2.
-function vercomp() {
+vercomp() {
     if [[ $1 == $2 ]]
     then
         return 0
@@ -62,7 +77,7 @@ function vercomp() {
     then
         max_len=$len2
     fi
-    for i in `seq 0 $max_len`
+    for i in $(seq 0 $max_len)
     do
         # Fill empty fields with zeros in v1
         if [ -z "${v1[$i]}" ]
@@ -102,7 +117,33 @@ Path=${1:-rustlings/}
 echo "Cloning Rustlings at $Path..."
 git clone -q https://github.com/rust-lang/rustlings $Path
 
-Version=$(curl -s https://api.github.com/repos/rust-lang/rustlings/releases/latest | ${PY} -c "import json,sys;obj=json.load(sys.stdin);print(obj['tag_name']);")
+# function to locate the version number from the latest releases JSON
+locate_version(){
+  if [ "$JQ" ]&&[ -x "$JQ" ]
+  then
+    curl -s https://api.github.com/repos/rust-lang/rustlings/releases/latest | $JQ -r .tag_name
+  else # try to use shell to locate the version number in the json
+    VER=$(curl -s https://api.github.com/repos/rust-lang/rustlings/releases/latest|grep tag_name)
+    VER=${VER%\"*}
+    VER=${VER##*\"}
+    if [ "$VER" ]&& echo "$VER"|grep -q '^[[:digit:]]*\.[[:digit:]]*'
+    then # check that we have something that resembles a reasonable and valid version number
+        echo $VER
+    else
+      # last chance to find a version number by asking git itself
+      VER=$(git tag|tail -n1|tr -d '\n') #take the last tag and strip new lines
+      if [ "$VER" ]&& echo "$VER"|grep -q '^[[:digit:]]*\.[[:digit:]]*'
+      then
+        echo $VER
+      else
+        echo "ERROR: unable to locate version number" >&2
+        exit 1
+      fi
+    fi
+  fi
+}
+
+Version="$(locate_version)"
 CargoBin="${CARGO_HOME:-$HOME/.cargo}/bin"
 
 echo "Checking out version $Version..."
@@ -112,7 +153,7 @@ git checkout -q tags/$Version
 echo "Installing the 'rustlings' executable..."
 cargo install --force --path .
 
-if ! [ -x "$(command -v rustlings)" ]
+if ! [ -x "$($WHICH_CMD rustlings)" ]
 then
     echo "WARNING: Please check that you have '$CargoBin' in your PATH environment variable!"
 fi

--- a/src/exercise.rs
+++ b/src/exercise.rs
@@ -126,6 +126,12 @@ path = "{}.rs""#,
         .expect("Failed to run 'compile' command.");
 
         if cmd.status.success() {
+            // Because compiler warnings go to the standard error, we have to inspect the
+            // standard error of the child process responsible for compiling the code.
+            if !cmd.stderr.is_empty() {
+                println!("{}", String::from_utf8_lossy(&cmd.stderr).to_string());
+                //fs::write!(format!("[DEBUG] {}\n", String::from_utf8_lossy(&cmd.stderr).to_string()));
+            }
             Ok(CompiledExercise {
                 exercise: &self,
                 _handle: FileHandle,


### PR DESCRIPTION
Example of install.sh without python and with the option to use jq where it is installed.